### PR TITLE
Fix g++ 8.3.0 compilation errors

### DIFF
--- a/src/next.cpp
+++ b/src/next.cpp
@@ -1846,7 +1846,7 @@ namespace next
             memcpy( &int_value, &value, 4 );
         }
         bool result = stream.SerializeBits( int_value, 32 );
-        if ( Stream::IsReading )
+        if ( Stream::IsReading && result )
         {
             memcpy( &value, &int_value, 4 );
         }

--- a/src/next_linux.cpp
+++ b/src/next_linux.cpp
@@ -803,7 +803,7 @@ static int get_connection_type()
         {
             struct ifreq req;
             memset( &req, 0, sizeof( req ) );
-            strncpy( req.ifr_name, i->ifa_name, IFNAMSIZ );
+            strncpy( req.ifr_name, i->ifa_name, IFNAMSIZ - 1 );
 
             if ( ioctl( sock, SIOCGIFINDEX, &req ) == -1 )
             {
@@ -832,7 +832,7 @@ static int get_connection_type()
 
             struct iwreq pwrq;
             memset( &pwrq, 0, sizeof( pwrq ) );
-            strncpy( pwrq.ifr_name, i->ifa_name, IFNAMSIZ );
+            strncpy( pwrq.ifr_name, i->ifa_name, IFNAMSIZ - 1 );
 
             if ( ioctl( sock, SIOCGIWNAME, &pwrq ) == -1 )
             {


### PR DESCRIPTION
Fixes #3.

## Testing Done
Not much. Just ran `./server` and `./client` and verified they didn't crash or have any errors printed to their logs.